### PR TITLE
Fix Devtools stream send helper

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -43,10 +43,14 @@ const app = new App({
 });
 
 // Simple message handler that returns extracted insights as an Adaptive Card
-app.on("message", async ({ context, activity }) => {
+app.on("message", async ({ context, stream, activity }) => {
+  const send = context?.sendActivity
+    ? (m: any) => context.sendActivity(m)
+    : (m: any) => stream.emit({ type: "message", value: m });
+
   const text = activity.text?.toLowerCase() ?? "";
   if (!text.startsWith("insights")) {
-    await context.sendActivity("Send 'insights' to fetch community feedback.");
+    await send("Send 'insights' to fetch community feedback.");
     return;
   }
 
@@ -72,7 +76,7 @@ app.on("message", async ({ context, activity }) => {
     })),
   };
 
-  await context.sendActivity({
+  await send({
     attachments: [
       { contentType: "application/vnd.microsoft.card.adaptive", content: card },
     ],


### PR DESCRIPTION
## Summary
- update message handler to accept `stream`
- add send helper to fall back to stream emit
- use helper for intro and card responses

## Testing
- `npm run build` *(fails: EHOSTUNREACH)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node')*