### PR TITLE
Improve insight card generation

### DIFF
--- a/bot/src/collector/github.ts
+++ b/bot/src/collector/github.ts
@@ -16,7 +16,7 @@ repo  = "microsoft-teams-library-js",
     id: `gh-${issue.id}`,
     source: "github",
     url: issue.html_url!,
-    text:issue.title,
     text: issue.title + "\n\n" + (issue.body || ""),
+    createdAt: issue.created_at,
   }));
 }

--- a/bot/src/collector/stack.ts
+++ b/bot/src/collector/stack.ts
@@ -22,11 +22,11 @@ export async function fetchStackPosts(
     },
   });
 
-  return res.data.items.map((q: any) => (
-    {
+  return res.data.items.map((q: any) => ({
     id: `so-${q.question_id}`,
     source: "stackoverflow",
     url: q.link,
-    text: `${q.title}\n\n${q.body_markdown ?? q.body ?? ""}`
+    text: `${q.title}\n\n${q.body_markdown ?? q.body ?? ""}`,
+    createdAt: new Date(q.creation_date * 1000).toISOString(),
   }));
 }


### PR DESCRIPTION
## Summary
- fix GitHub collector duplicate field and capture creation time
- return creation time for Stack Overflow posts
- deduplicate insights by summary and compute age
- send one adaptive card per insight with category, summary, severity and age

## Testing
- `npm run build` *(fails: request to https://registry.npmjs.org/tsup failed, reason: connect EHOSTUNREACH 172.24.0.3:8080)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*