### PR TITLE
Auto run feedback client on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ npm run dev
 
 The bot exposes an MCP server at `http://localhost:3000/mcp` and a devtools inspector at `http://localhost:6274/`.
 
-Send `insights` to the bot in Teams or in the MCP inspector to fetch the latest GitHub issues and Stack Overflow questions. The bot analyzes the items with the configured model and returns an Adaptive Card containing categorized summaries and severity estimates.
+`npm run dev` now also launches the feedback client which polls GitHub and Stack Overflow every five minutes and forwards posts to the server.
+
+After the client has ingested posts, send `insights` to the bot in Teams (or in the MCP inspector) to analyze the collected feedback. The bot returns an Adaptive Card with categorized summaries and severity estimates.
 
 ## Building for Production
 

--- a/bot/src/client.ts
+++ b/bot/src/client.ts
@@ -1,0 +1,38 @@
+import "dotenv/config";
+import { ChatPrompt } from "@microsoft/teams.ai";
+import { McpClientPlugin } from "@microsoft/teams.mcpclient";
+import { fetchGitHubIssues } from "./collector/github";
+import { fetchStackPosts } from "./collector/stack";
+import { myModel } from "./modelInstance";
+
+/**
+ * Shared prompt used by the feedback client to forward items
+ * to the server's `ingestFeedback` tool.
+ */
+const mcpUrl = process.env.MCP_SERVER_URL || "http://localhost:3000/mcp";
+const clientPrompt = new ChatPrompt(
+  {
+    instructions: "Forward community posts to the ingestFeedback tool.",
+    model: myModel,
+  },
+  [new McpClientPlugin()]
+).usePlugin("mcpClient", { url: mcpUrl });
+
+export async function runClient() {
+  const items = [
+    ...(await fetchGitHubIssues()),
+    ...(await fetchStackPosts()),
+  ];
+  const command = `ingestFeedback(${JSON.stringify({ items })})`;
+  await clientPrompt.send(`Please execute ${command}`);
+  console.log(`Sent ${items.length} items via MCP client.`);
+}
+
+export function startClientPolling(intervalMs = 5 * 60 * 1000) {
+  runClient();
+  setInterval(runClient, intervalMs);
+}
+
+if (require.main === module) {
+  startClientPolling();
+}

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -1,12 +1,13 @@
 import { App } from "@microsoft/teams.apps";
 import { DevtoolsPlugin } from "@microsoft/teams.dev";
 import { McpPlugin } from "@microsoft/teams.mcp";
-import { fetchStackPosts } from "./collector/stack";
-import { fetchGitHubIssues } from "./collector/github";
 import { extractInsights } from "./extractor";
+import { startClientPolling } from "./client";
 import { z } from "zod";
 
 // Create MCP server plugin with a simple echo and data collection tool
+const feedbackItems: any[] = [];
+
 const mcpServerPlugin = new McpPlugin({
   name: "community-insights",
   description: "MCP server for collecting community feedback",
@@ -23,17 +24,24 @@ const mcpServerPlugin = new McpPlugin({
     {}
   )
   .tool(
-    "collectInsights",
-    "Fetch latest SO & GH posts",
-    z.object({}),
-    async () => {
-      const items = [
-        ...(await fetchGitHubIssues()),
-        ...(await fetchStackPosts()),
-      ];
-      return {
-        content: [{ type: "text", text: JSON.stringify(items) }],
-      };
+    "ingestFeedback",
+    "Store feedback items provided by the MCP client",
+    z.object({
+      items: z
+        .array(
+          z.object({
+            id: z.string(),
+            source: z.string(),
+            url: z.string(),
+            text: z.string(),
+            createdAt: z.string(),
+          })
+        )
+        .describe("feedback items"),
+    }),
+    async ({ items }: { items: any[] }) => {
+      feedbackItems.push(...items);
+      return { content: [{ type: "text", text: "ok" }] };
     },
     {}
   );
@@ -59,10 +67,11 @@ app.on("message", async ({ context, stream, activity }) => {
     return;
   }
 
-  const posts = [
-    ...(await fetchGitHubIssues()),
-    ...(await fetchStackPosts()),
-  ];
+  const posts = feedbackItems.splice(0, feedbackItems.length);
+  if (posts.length === 0) {
+    await send("No feedback available. Run the client to ingest posts.");
+    return;
+  }
 
   const deduped = new Map<string, any>();
 
@@ -100,3 +109,6 @@ app.on("message", async ({ context, stream, activity }) => {
 });
 
 app.start();
+
+// Start the feedback client on an interval when running in dev mode
+startClientPolling();

--- a/bot/tsup.config.js
+++ b/bot/tsup.config.js
@@ -8,6 +8,6 @@ module.exports = {
   splitting: true,
   clean: true,
   outDir: 'dist',
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/client.ts'],
   format: ['cjs'],
 };


### PR DESCRIPTION
## Summary
- invoke client polling from the dev server so the bot automatically ingests posts
- document that the client now runs every five minutes when using `npm run dev`

## Testing
- `npm run build` *(fails: connect EHOSTUNREACH)*