### PR TITLE
Add MCP server check

### DIFF
--- a/bot/src/client.ts
+++ b/bot/src/client.ts
@@ -1,21 +1,36 @@
 import "dotenv/config";
 import { ChatPrompt } from "@microsoft/teams.ai";
 import { McpClientPlugin } from "@microsoft/teams.mcpclient";
+import axios from "axios";
 import { fetchGitHubIssues } from "./collector/github";
 import { fetchStackPosts } from "./collector/stack";
 import { myModel } from "./modelInstance";
 
 const mcpUrl = process.env.MCP_SERVER_URL || "http://localhost:3000/mcp";
 
-const clientPrompt = new ChatPrompt(
-  {
-    instructions: "Forward community posts to the ingestFeedback tool.",
-    model: myModel,
-  },
-  [new McpClientPlugin()]
-).usePlugin("mcpClient", { url: mcpUrl });
+async function createPrompt() {
+  try {
+    await axios.get(mcpUrl);
+  } catch {
+    console.error(`Unable to reach MCP server at ${mcpUrl}. Is the server running?`);
+    process.exit(1);
+  }
 
-async function runClient() {
+  try {
+    return new ChatPrompt(
+      {
+        instructions: "Forward community posts to the ingestFeedback tool.",
+        model: myModel,
+      },
+      [new McpClientPlugin()]
+    ).usePlugin("mcpClient", { url: mcpUrl });
+  } catch {
+    console.warn(`Could not load MCP schema; is the server running at ${mcpUrl}?`);
+    process.exit(1);
+  }
+}
+
+async function runClient(prompt: ChatPrompt) {
   const items = [
     ...(await fetchGitHubIssues()),
     ...(await fetchStackPosts()),
@@ -27,9 +42,12 @@ async function runClient() {
   }
 
   const command = `ingestFeedback(${JSON.stringify({ items })})`;
-  await clientPrompt.send(`Please execute ${command}`);
+  await prompt.send(`Please execute ${command}`);
   console.log(`Sent ${items.length} items via MCP client.`);
 }
 
-runClient();
-setInterval(runClient, 5 * 60 * 1000);
+(async () => {
+  const clientPrompt = await createPrompt();
+  await runClient(clientPrompt);
+  setInterval(() => runClient(clientPrompt), 5 * 60 * 1000);
+})();


### PR DESCRIPTION
## Summary
- ping MCP server before creating `ChatPrompt`
- warn and exit if MCP server can't be reached
- catch schema load failures when creating MCP client

## Testing
- `npm run build` *(fails: EHOSTUNREACH)*