### PR TITLE
Fix message output for hi prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ To start the bot locally with hot‑reloading:
 npm run dev
 ```
 
-The bot exposes an MCP server at `http://localhost:3000/mcp` and a devtools inspector at `http://localhost:6274/`.
+The bot exposes an MCP server at `http://localhost:3000/mcp` and a devtools inspector at
+`http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:3000/mcp`.
+Open that full URL in your browser so the inspector connects to the running server.
 
 Run the MCP client in **another terminal** so it connects to the running server. The client continuously pulls posts every five minutes:
 

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -52,15 +52,15 @@ const app = new App({
 // Simple message handler that returns extracted insights as an Adaptive Card
 app.on("message", async ({ context, stream, activity }) => {
   const send = (msg: any) => {
+    const activityMsg =
+      typeof msg === "string" ? { type: "message", text: msg } : { type: "message", ...msg };
     if (context?.sendActivity) {
-      return context.sendActivity(msg);
+      return context.sendActivity(activityMsg);
     }
-    const activity =
-      typeof msg === "string" ? { type: "message", text: msg } : msg;
-    return stream.emit(activity);
+    return stream.emit(activityMsg);
   };
 
-  const text = activity.text?.toLowerCase() ?? "";
+  const text = activity.text?.trim().toLowerCase() ?? "";
   if (!text.startsWith("insights")) {
     await send("Send 'insights' to fetch community feedback.");
     return;


### PR DESCRIPTION
## Summary
- ensure outgoing messages always specify `message` type
- trim incoming text before checking for `insights`

## Testing
- `pre-commit` *(fails: command not found)*
- `npm run build` *(fails: EHOSTUNREACH while fetching tsup)*