### PR TITLE
Implement simple caching for client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ coverage/
 
 # Optional: Ignore test output
 test-results/
+ingested.json

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ npx ts-node src/client.ts   # in another terminal
 
 Adjust the `MCP_SERVER_URL` environment variable if you change the port from the default.
 
+The client records ingested post IDs in `bot/ingested.json`. Subsequent runs
+only send new items. Delete this file if you want to re-ingest everything.
+
 After ingesting posts, send `insights` to the bot in Teams (or in the MCP inspector) to analyze the collected feedback. The bot returns an Adaptive Card with categorized summaries and severity estimates.
 
 ## Building for Production

--- a/bot/src/cache.ts
+++ b/bot/src/cache.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const cachePath = path.resolve(__dirname, '../ingested.json');
+
+export function loadCache(): Set<string> {
+  try {
+    const data = fs.readFileSync(cachePath, 'utf-8');
+    return new Set(JSON.parse(data));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveCache(ids: Set<string>) {
+  try {
+    fs.writeFileSync(cachePath, JSON.stringify(Array.from(ids), null, 2));
+  } catch (err) {
+    console.error('Failed to write cache', err);
+  }
+}

--- a/bot/src/client.ts
+++ b/bot/src/client.ts
@@ -3,9 +3,13 @@ import { ChatPrompt } from "@microsoft/teams.ai";
 import { McpClientPlugin } from "@microsoft/teams.mcpclient";
 import { fetchGitHubIssues } from "./collector/github";
 import { fetchStackPosts } from "./collector/stack";
+import { loadCache, saveCache } from "./cache";
 import { myModel } from "./modelInstance";
 
 const mcpUrl = process.env.MCP_SERVER_URL || "http://localhost:3000/mcp";
+
+// Track previously ingested post IDs to avoid resending them
+const ingestedIds = loadCache();
 
 async function createPrompt() {
   try {
@@ -36,17 +40,19 @@ async function runClient(prompt: ChatPrompt) {
 
   console.log(`Fetched ${items.length} items from sources`);
 
+  const newItems = items.filter((i) => !ingestedIds.has(i.id));
 
-  if (items.length === 0) {
+  if (newItems.length === 0) {
     console.log("No new posts found");
     return;
+  } else {
+    console.log(`Found ${newItems.length} new posts`);
   }
-  else{
-    console.log(`Found ${items.length} new posts`);
-  }
-  const command = `ingestFeedback(${JSON.stringify({ items })})`;
+  const command = `ingestFeedback(${JSON.stringify({ items: newItems })})`;
   await prompt.send(`Please execute ${command}`);
-  console.log(`Sent ${items.length} items via MCP client.`);
+  console.log(`Sent ${newItems.length} items via MCP client.`);
+  newItems.forEach((i) => ingestedIds.add(i.id));
+  saveCache(ingestedIds);
 }
 
 (async () => {


### PR DESCRIPTION
## Summary
- track ingested post IDs on the client
- write helper module for persisting IDs
- mention the new cache file in README
- ignore the generated cache file

## Testing
- `npm --prefix bot run build` *(fails: EHOSTUNREACH)*