### PR TITLE
Add few-shot prompt file for insight extraction

### DIFF
--- a/bot/src/extractor.ts
+++ b/bot/src/extractor.ts
@@ -1,15 +1,15 @@
 import { ChatPrompt } from "@microsoft/teams.ai";
 import { myModel } from "./modelInstance";
+import fs from "fs";
+import path from "path";
+
+// Load few-shot prompt template for extraction
+const templatePath = path.resolve(__dirname, "prompts/extractor.txt");
+const instructions = fs.readFileSync(templatePath, "utf-8");
 
 // Prompt to extract structured insights from raw text
 const extractorPrompt = new ChatPrompt({
-  instructions: `
-You receive a block of text (a StackOverflow question or GitHub issue).
-Extract and return a JSON object with exactly these keys:
-  • category (one word)
-  • summary (a one-sentence pain-point description)
-  • severity (Low, Medium, or High)
-Respond *only* with the JSON.`,
+  instructions,
   model: myModel,
 });
 

--- a/bot/src/prompts/extractor.txt
+++ b/bot/src/prompts/extractor.txt
@@ -1,0 +1,14 @@
+You receive a block of text from a Stack Overflow question or GitHub issue. Extract a JSON object with exactly these keys:
+- category: a single word summarizing the main topic
+- summary: one sentence describing the user's pain point
+- severity: Low, Medium, or High depending on how serious the problem appears
+
+Example
+Post: "I'm developing a Teams bot using the Bot Framework. The bot works in a 1:1 chat but doesn't respond when added to a group. Any idea what I'm missing?"
+{"category":"bot","summary":"Bot built with Bot Framework does not respond in group chats.","severity":"Medium"}
+
+Example
+Post: "Cannot install the teamsfx-cli on Ubuntu 22.04. npm reports 'preinstall script not found'."
+{"category":"installation","summary":"teamsfx-cli fails to install on Ubuntu 22.04 due to missing preinstall script.","severity":"High"}
+
+Return just the JSON for any new post.


### PR DESCRIPTION
## Summary
- add a reusable template with example Stack Overflow and GitHub posts
- load the template in extractor instead of hard-coded instruction

## Testing
- `npm run build` *(fails: EHOSTUNREACH)*